### PR TITLE
서치 바의 각 컴포넌트 값을 set payload

### DIFF
--- a/src/hooks/useSearchPayload.ts
+++ b/src/hooks/useSearchPayload.ts
@@ -1,0 +1,9 @@
+import useKeywordState from './useKeywordState';
+import useGuestCountState from './useGuestCountState';
+
+export default function useSearchPayload() {
+  const { keyword: hotelName } = useKeywordState();
+  const { total: max } = useGuestCountState();
+
+  return { hotelName, max };
+}

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -1,26 +1,16 @@
 import React from 'react';
 import styled from 'styled-components';
 import Search from './search';
+import { ISearchPayload } from '../../types';
 import { getHotels } from '../../queries/hotel';
 
 export default function Main() {
-  const [payload, setPayload] = React.useState({ hotelName: '', max: 0 });
-  const { data: hotels, isLoading } = getHotels(payload);
-
-  if (hotels === undefined) {
-    return <></>;
-  }
+  const [payload, setPayload] = React.useState<ISearchPayload>({ hotelName: '', max: 0 });
+  // const { data: hotels, isLoading } = getHotels(payload);
 
   return (
     <Wrapper>
-      <Search />
-      <>
-        {isLoading
-          ? ''
-          : hotels.map((hotel) => {
-              console.log(hotel);
-            })}
-      </>
+      <Search setPayload={setPayload} />
     </Wrapper>
   );
 }

--- a/src/pages/main/search/desktop/index.tsx
+++ b/src/pages/main/search/desktop/index.tsx
@@ -1,17 +1,29 @@
 import React from 'react';
 import styled from 'styled-components';
+import { ISearchPayload } from '../../../../types';
+import useSearchPayload from '../../../../hooks/useSearchPayload';
 import Count from './Count';
 import Schedule from './Schedule';
 import Text from './Text';
 import SearchIcon from '@mui/icons-material/Search';
 
-export default function Search() {
+interface ISearchProps {
+  setPayload: React.Dispatch<React.SetStateAction<ISearchPayload>>;
+}
+
+export default function Search({ setPayload }: ISearchProps) {
+  const payload = useSearchPayload();
+
+  const handleSearchClick = () => {
+    setPayload(payload);
+  };
+
   return (
     <Wrapper>
       <Text />
       <Schedule />
       <Count />
-      <Button>
+      <Button onClick={handleSearchClick}>
         <StyledSearchIcon fontSize='large' />
       </Button>
     </Wrapper>

--- a/src/pages/main/search/index.tsx
+++ b/src/pages/main/search/index.tsx
@@ -1,9 +1,16 @@
 import React from 'react';
 import { useMediaQuery } from 'react-responsive';
+import { ISearchPayload } from '../../../types';
 import Desktop from './desktop';
 import Mobile from './mobile';
 
-export default function index() {
+interface ISearchProps {
+  setPayload: React.Dispatch<React.SetStateAction<ISearchPayload>>;
+}
+
+export default function index({ setPayload }: ISearchProps) {
   const isDesktop = useMediaQuery({ minWidth: 1024 });
-  return <>{isDesktop ? <Desktop /> : <Mobile />}</>;
+  return (
+    <>{isDesktop ? <Desktop setPayload={setPayload} /> : <Mobile setPayload={setPayload} />}</>
+  );
 }

--- a/src/pages/main/search/mobile/index.tsx
+++ b/src/pages/main/search/mobile/index.tsx
@@ -1,10 +1,22 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
+import { ISearchPayload } from '../../../../types';
+import useSearchPayload from '../../../../hooks/useSearchPayload';
 import Count from './Count';
 import Schedule from './Schedule';
 import Text from './Text';
 
-export default function Search() {
+interface ISearchProps {
+  setPayload: React.Dispatch<React.SetStateAction<ISearchPayload>>;
+}
+
+export default function Search({ setPayload }: ISearchProps) {
+  const payload = useSearchPayload();
+
+  useEffect(() => {
+    setPayload(payload);
+  }, [payload]);
+
   return (
     <Wrapper>
       <Text />


### PR DESCRIPTION
# 개요
- 서치 바 에서 관리되는 값들을 payload에 반영하는 작업
- 데스크탑은 버튼을 눌렀을 때
- 모바일은 useEffect에서 set

# 추후 작업
- 일정과 인원 선택하는 팝업을 붙이고 값이 제대로 바뀌나 테스트 필요.