### PR TITLE
팝업 띄우는 역할을 외부로 위임

### DIFF
--- a/src/pages/main/search/Popup.tsx
+++ b/src/pages/main/search/Popup.tsx
@@ -17,28 +17,20 @@ export function usePopup() {
 interface IPopup {
   top: number;
   left: number;
-  isOpen: boolean;
   close: () => void;
   children: JSX.Element;
 }
 
-export function Popup({ top, left, isOpen, close, children }: IPopup) {
+export function Popup({ top, left, close, children }: IPopup) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
-    if (isOpen && wrapperRef.current) {
+    if (wrapperRef.current) {
       wrapperRef.current.focus();
     }
-  }, [isOpen]);
+  }, []);
 
   return (
-    <Wrapper
-      ref={wrapperRef}
-      tabIndex={0}
-      top={top}
-      left={left}
-      isOpen={isOpen}
-      onBlur={() => close()}
-    >
+    <Wrapper ref={wrapperRef} tabIndex={0} top={top} left={left} onBlur={() => close()}>
       {children}
     </Wrapper>
   );
@@ -47,9 +39,7 @@ export function Popup({ top, left, isOpen, close, children }: IPopup) {
 const Wrapper = styled.div<{
   top: number;
   left: number;
-  isOpen: boolean;
 }>`
-  display: ${({ isOpen }) => (isOpen ? 'block' : 'none')};
   position: absolute;
   top: ${({ top }) => top};
   left: ${({ left }) => left};

--- a/src/pages/main/search/desktop/Count.tsx
+++ b/src/pages/main/search/desktop/Count.tsx
@@ -19,7 +19,7 @@ export default function Count() {
         </CountWrapper>
       </Contents>
       {isOpen && (
-        <Popup top={60} left={0} isOpen={isOpen} close={close}>
+        <Popup top={60} left={0} close={close}>
           <GuestSelect adult={adult} child={child} onChange={onChange} />
         </Popup>
       )}

--- a/src/pages/main/search/desktop/Schedule.tsx
+++ b/src/pages/main/search/desktop/Schedule.tsx
@@ -24,9 +24,11 @@ export default function Schedule() {
           </CheckWrapper>
         </DateWrapper>
       </Contents>
-      <Popup top={60} left={0} isOpen={isOpen} close={close}>
-        <PopupTest>달력</PopupTest>
-      </Popup>
+      {isOpen && (
+        <Popup top={60} left={0} close={close}>
+          <PopupTest>달력</PopupTest>
+        </Popup>
+      )}
     </Wrapper>
   );
 }

--- a/src/pages/main/search/mobile/Count.tsx
+++ b/src/pages/main/search/mobile/Count.tsx
@@ -21,7 +21,7 @@ export default function Count() {
         </CountWrapper>
       </Contents>
       {isOpen && (
-        <Popup top={0} left={0} isOpen={isOpen} close={close}>
+        <Popup top={0} left={0} close={close}>
           <PopupTest>
             <GuestSelect adult={adult} child={child} onChange={onChange} />
           </PopupTest>

--- a/src/pages/main/search/mobile/Schedule.tsx
+++ b/src/pages/main/search/mobile/Schedule.tsx
@@ -13,9 +13,11 @@ export default function Schedule() {
         <DateText>{checkInFullString}</DateText>
         <DateText>{checkOutFullString}</DateText>
       </Contents>
-      <Popup top={0} left={0} isOpen={isOpen} close={close}>
-        <PopupTest>달력</PopupTest>
-      </Popup>
+      {isOpen && (
+        <Popup top={0} left={0} close={close}>
+          <PopupTest>달력</PopupTest>
+        </Popup>
+      )}
     </Wrapper>
   );
 }


### PR DESCRIPTION
# 개요
- 팝업 띄우는 역할을 외부로 위임
- 기존의 팝업은 팝업 내부에서 isOpen으로 display를 none으로 바꾸는 방법으로 구현했었음
- 이렇게 할 경우 팝업 내부에 컴포넌트가 미리 그려지는 문제가 있음
- 그렇다고 해서 특별한 문제는 없지만...
- 외부에서 {isOpen && <popup />} 이런 방식으로 아예 그리지 않는게 더 좋다고 판단했음.