### PR TITLE
호텔정보 카드 스타일 수정

### DIFF
--- a/src/pages/main/card/Card.tsx
+++ b/src/pages/main/card/Card.tsx
@@ -20,7 +20,7 @@ function Card(props: IHotelCard) {
   };
 
   return (
-    <Container sx={{ boxShadow: 'rgb(94 94 94 / 10%) 0px 2px 4px 0px' }} disabled={reservation}>
+    <Container disabled={reservation}>
       <ImgWrapper>
         <Img src={mockImg} alt={hotelName} />
       </ImgWrapper>

--- a/src/pages/main/card/Card.tsx
+++ b/src/pages/main/card/Card.tsx
@@ -32,9 +32,7 @@ function Card(props: IHotelCard) {
           기준 {base}인 | 최대 {max}인
         </Typography>
       </Info>
-      <ReservationButton disabled={reservation} onClick={() => handleClick(id)}>
-        예약
-      </ReservationButton>
+      <ReservationButton disabled={reservation} onClick={() => handleClick(id)} />
     </Container>
   );
 }
@@ -43,12 +41,10 @@ export default Card;
 
 const mockImg = 'https://i.travelapi.com/hotels/1000000/30000/25000/24908/4a391ebd_b.jpg';
 const Container = styled(GridCard)<{ disabled: boolean }>`
-  color: ${({ disabled }) => (disabled ? 'lightGray' : 'inherit')};
-  filter: ${({ disabled }) => disabled && 'grayscale(100%)'};
-  opacity: ${({ disabled }) => disabled && '0.7'};
-  & > button {
-    cursor: ${({ disabled }) => disabled && 'default'};
+  & > * {
+    color: ${({ disabled }) => (disabled ? 'lightGray' : 'inherit')};
   }
+  opacity: ${({ disabled }) => disabled && '0.5'};
 `;
 
 const ImgWrapper = styled.div`
@@ -80,6 +76,9 @@ const Typography = styled.p<{ fontWeight?: string; fontSize?: string; color?: st
 `;
 
 const ReservationButton = styled.button`
+  &::before {
+    content: '예약';
+  }
   grid-area: button;
   background-color: #ff375c;
   border-radius: 5px;
@@ -88,4 +87,11 @@ const ReservationButton = styled.button`
   width: fit-content;
   justify-self: right;
   cursor: pointer;
+  &:disabled {
+    background-color: lightgray;
+    cursor: default;
+    &::before {
+      content: '마감';
+    }
+  }
 `;

--- a/src/pages/main/card/GridCard.tsx
+++ b/src/pages/main/card/GridCard.tsx
@@ -1,11 +1,12 @@
 import styled from 'styled-components';
-import { Card } from '@mui/material';
 
-const GridCard = styled(Card)`
+const GridCard = styled.div`
   max-width: 650px;
   width: 100%;
   display: grid;
   align-items: center;
+  box-shadow: #e4e4e4 2px 2px 4px 2px;
+  border-radius: 5px;
   aspect-ratio: 3 / 1;
   padding: 0 10px;
   column-gap: 10px;

--- a/src/pages/main/card/Skeleton.tsx
+++ b/src/pages/main/card/Skeleton.tsx
@@ -6,7 +6,7 @@ const skeletonRepeatCount = Array(10).fill(0);
 
 function CardSkeleton() {
   return (
-    <Container sx={{ boxShadow: 'rgb(94 94 94 / 10%) 0px 2px 4px 0px' }}>
+    <Container>
       <Empty />
       <Empty />
       <Empty />

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -55,6 +55,7 @@ const Wrapper = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  gap: 20px;
 `;
 
 const CardContainer = styled.div`

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -68,7 +68,7 @@ const CardContainer = styled.div`
   grid-auto-rows: auto;
   grid-gap: 10px;
   place-items: center center;
-  @media screen and (max-width: 480px) {
+  @media screen and (max-width: 976px) {
     grid-template-columns: 1fr;
   }
 `;

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -62,7 +62,6 @@ const CardContainer = styled.div`
   max-width: 976px;
   width: 100%;
   margin: 0 auto;
-  background-color: #ededed;
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   grid-auto-rows: auto;

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,4 +1,3 @@
-import { IHotel } from '../types';
 import { generateReservationDateInfo } from './date';
 
 const LOCALSTORAGE_KEY = 'hotels';


### PR DESCRIPTION
# 개요
호텔정보 카드 스타일 수정

# 변경사항
- [x] 검색바와 카드 사이 여백
- [x] 태블릿사이즈(976px)에서도 카드 한 줄로 보이게 수정
- [x] 예약완료 카드에서 grayscale필터 빼고 opacity 조정
- [x] 예약완료/예약가능 버튼 문구 다르게

# 사진
![image](https://user-images.githubusercontent.com/49019236/182746644-7c2b12a0-800e-4572-8e16-45053f69193b.png)

# 추가고려사항
* 나타날 때 애니메이션 넣을 수 있으면 넣어보겠습니다.