### PR TITLE
모바일 사이즈 팝업 구현

### DIFF
--- a/src/components/FullSizePopup.tsx
+++ b/src/components/FullSizePopup.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect } from 'react';
+import styled from 'styled-components';
+import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
+
+interface IFullSizePopup {
+  title: string;
+  close: () => void;
+  children: JSX.Element;
+}
+
+export default function FullSizePopup({ title, close, children }: IFullSizePopup) {
+  useEffect(() => {
+    disableScroll();
+  }, []);
+
+  return (
+    <Wrapper>
+      <Header>
+        <Title>{title}</Title>
+        <CloseButtonWrapper onClick={close}>
+          <CloseRoundedIcon style={{ fontSize: '10vw' }} />
+        </CloseButtonWrapper>
+      </Header>
+      {children}
+    </Wrapper>
+  );
+}
+
+function disableScroll() {
+  document.body.style.cssText = `position: fixed; top: -${window.scrollY}px`;
+  return () => {
+    const scrollY = document.body.style.top;
+    document.body.style.cssText = 'position: ""; top: "";';
+    window.scrollTo(0, parseInt(scrollY || '0') * -1);
+  };
+}
+
+const Wrapper = styled.div`
+  width: 100vw;
+  height: 100vh;
+`;
+
+const Header = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  padding: 6vw 5vw 6vw 5vw;
+  border-bottom: 1px solid #eeeeee;
+`;
+
+const Title = styled.h1`
+  position: relative;
+  top: -1px;
+  font-size: 6vw;
+  font-weight: 600;
+`;
+
+const CloseButtonWrapper = styled.div`
+  position: absolute;
+  top: 50%;
+  right: 5vw;
+  transform: translateY(-50%);
+  cursor: pointer;
+`;

--- a/src/components/FullSizePopup.tsx
+++ b/src/components/FullSizePopup.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { useMediaQuery } from 'react-responsive';
 import styled from 'styled-components';
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
 
@@ -9,6 +10,8 @@ interface IFullSizePopup {
 }
 
 export default function FullSizePopup({ title, close, children }: IFullSizePopup) {
+  const isMobile = useMediaQuery({ maxWidth: 480 });
+
   useEffect(() => {
     disableScroll();
   }, []);
@@ -18,7 +21,7 @@ export default function FullSizePopup({ title, close, children }: IFullSizePopup
       <Header>
         <Title>{title}</Title>
         <CloseButtonWrapper onClick={close}>
-          <CloseRoundedIcon style={{ fontSize: '10vw' }} />
+          <CloseRoundedIcon style={{ fontSize: isMobile ? '10vw' : '26px' }} />
         </CloseButtonWrapper>
       </Header>
       {children}
@@ -45,21 +48,33 @@ const Header = styled.div`
   justify-content: center;
   align-items: center;
   position: relative;
-  padding: 6vw 5vw 6vw 5vw;
+  padding: 18px;
   border-bottom: 1px solid #eeeeee;
+
+  @media screen and (max-width: 480px) {
+    padding: 6vw 5vw 6vw 5vw;
+  }
 `;
 
 const Title = styled.h1`
   position: relative;
   top: -1px;
-  font-size: 6vw;
+  font-size: 18px;
   font-weight: 600;
+
+  @media screen and (max-width: 480px) {
+    font-size: 6vw;
+  }
 `;
 
 const CloseButtonWrapper = styled.div`
   position: absolute;
   top: 50%;
-  right: 5vw;
+  right: 18px;
   transform: translateY(-50%);
   cursor: pointer;
+
+  @media screen and (max-width: 480x) {
+    right: 5vw;
+  }
 `;

--- a/src/components/FullSizePopup.tsx
+++ b/src/components/FullSizePopup.tsx
@@ -13,7 +13,7 @@ export default function FullSizePopup({ title, close, children }: IFullSizePopup
   const isMobile = useMediaQuery({ maxWidth: 480 });
 
   useEffect(() => {
-    disableScroll();
+    return disableScroll();
   }, []);
 
   return (

--- a/src/pages/main/search/Popup.tsx
+++ b/src/pages/main/search/Popup.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { useMediaQuery } from 'react-responsive';
 import styled from 'styled-components';
 
 export function usePopup() {
@@ -29,8 +30,15 @@ export function Popup({ top, left, close, children }: IPopup) {
     }
   }, []);
 
+  const isDesktop = useMediaQuery({ minWidth: 1024 });
+  const handleBlur = () => {
+    if (isDesktop) {
+      close();
+    }
+  };
+
   return (
-    <Wrapper ref={wrapperRef} tabIndex={0} top={top} left={left} onBlur={() => close()}>
+    <Wrapper ref={wrapperRef} tabIndex={0} top={top} left={left} onBlur={handleBlur}>
       {children}
     </Wrapper>
   );

--- a/src/pages/main/search/Popup.tsx
+++ b/src/pages/main/search/Popup.tsx
@@ -38,7 +38,14 @@ export function Popup({ top, left, close, children }: IPopup) {
   };
 
   return (
-    <Wrapper ref={wrapperRef} tabIndex={0} top={top} left={left} onBlur={handleBlur}>
+    <Wrapper
+      ref={wrapperRef}
+      tabIndex={0}
+      top={top}
+      left={left}
+      onBlur={handleBlur}
+      isDesktop={isDesktop}
+    >
       {children}
     </Wrapper>
   );
@@ -47,8 +54,9 @@ export function Popup({ top, left, close, children }: IPopup) {
 const Wrapper = styled.div<{
   top: number;
   left: number;
+  isDesktop: boolean;
 }>`
-  position: absolute;
+  position: ${({ isDesktop }) => (isDesktop ? 'absolute' : 'fixed')};
   top: ${({ top }) => `${top}px`};
   left: ${({ left }) => `${left}px`};
   background-color: white;

--- a/src/pages/main/search/mobile/Count.tsx
+++ b/src/pages/main/search/mobile/Count.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
 import useGuestCountState from '../../../../hooks/useGuestCountState';
-import GuestSelect from '../../../../components/guestselect/GuestSelect';
+import FullSizePopup from '../../../../components/FullSizePopup';
 import { usePopup, Popup } from '../Popup';
+import GuestSelect from '../../../../components/guestselect/GuestSelect';
 
 export default function Count() {
   const { isOpen, open, close } = usePopup();
@@ -22,9 +23,9 @@ export default function Count() {
       </Contents>
       {isOpen && (
         <Popup top={0} left={0} close={close}>
-          <PopupTest>
-            <GuestSelect adult={adult} child={child} onChange={onChange} />
-          </PopupTest>
+          <FullSizePopup title='인원 및 객실' close={close}>
+            <p>인원 및 객실</p>
+          </FullSizePopup>
         </Popup>
       )}
     </Wrapper>
@@ -69,10 +70,4 @@ const CountValue = styled.p`
   @media screen and (min-width: 768px) {
     font-size: 12px;
   }
-`;
-
-const PopupTest = styled.div`
-  background-color: lightcoral;
-  width: 100vw;
-  height: 100vh;
 `;

--- a/src/pages/main/search/mobile/Schedule.tsx
+++ b/src/pages/main/search/mobile/Schedule.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import styled from 'styled-components';
 import useScheduleState from '../../../../hooks/useScheduleState';
+import FullSizePopup from '../../../../components/FullSizePopup';
 import { usePopup, Popup } from '../Popup';
+import Datepicker from '../../../../components/datepicker';
 
 export default function Schedule() {
   const { isOpen, open, close } = usePopup();
-  const { checkInFullString, checkOutFullString, onChange } = useScheduleState();
+  const { checkInFullString, checkOutFullString, checkIn, checkOut, onChange } = useScheduleState();
 
   return (
     <Wrapper onMouseDown={open}>
@@ -15,7 +17,9 @@ export default function Schedule() {
       </Contents>
       {isOpen && (
         <Popup top={0} left={0} close={close}>
-          <PopupTest>달력</PopupTest>
+          <FullSizePopup title='일정' close={close}>
+            <p>달력</p>
+          </FullSizePopup>
         </Popup>
       )}
     </Wrapper>
@@ -43,10 +47,4 @@ const DateText = styled.p`
   @media screen and (min-width: 768px) {
     font-size: 12px;
   }
-`;
-
-const PopupTest = styled.div`
-  background-color: lightcoral;
-  width: 100vw;
-  height: 100vh;
 `;


### PR DESCRIPTION
# 개요
- 모바일 사이즈에서 나타나는 꽉 찬 화면의 팝업 구현

# 구현
![image](https://user-images.githubusercontent.com/83255812/182771798-95dce163-e319-4d27-94c0-582698e6c604.png)

```javascript
  return (
    <Wrapper onMouseDown={open}>
      <Contents>
        <DateText>{checkInFullString}</DateText>
        <DateText>{checkOutFullString}</DateText>
      </Contents>
      {isOpen && (
        <Popup top={0} left={0} close={close}>
          <FullSizePopup title='일정' close={close}>
            <p>달력</p>
          </FullSizePopup>
        </Popup>
      )}
    </Wrapper>
  );
```

p 태그를 본인의 컴포넌트로 교체해주시면 됩니다.
X 버튼 누르면 팝업 그냥 닫히고
모바일 일 땐 선택 완료 버튼을 눌렀을 때 onChange 를 호출해주시면 되겠습니다~