### PR TITLE
모바일 팝업 스크롤 막음

### DIFF
--- a/src/components/FullSizePopup.tsx
+++ b/src/components/FullSizePopup.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import { useMediaQuery } from 'react-responsive';
 import styled from 'styled-components';
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
@@ -11,16 +11,13 @@ interface IFullSizePopup {
 
 export default function FullSizePopup({ title, close, children }: IFullSizePopup) {
   const isMobile = useMediaQuery({ maxWidth: 480 });
-  const wrapperRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (wrapperRef) {
-      return disableScroll(wrapperRef as React.MutableRefObject<HTMLDivElement>);
-    }
+    return disableScroll();
   }, []);
 
   return (
-    <Wrapper ref={wrapperRef}>
+    <Wrapper>
       <Header>
         <Title>{title}</Title>
         <CloseButtonWrapper onClick={close}>
@@ -32,9 +29,8 @@ export default function FullSizePopup({ title, close, children }: IFullSizePopup
   );
 }
 
-function disableScroll(ref: React.MutableRefObject<HTMLDivElement>) {
+function disableScroll() {
   document.body.style.cssText = 'overflow: hidden;';
-  ref.current.style.cssText = 'overflow: auto;';
   return () => {
     document.body.style.cssText = 'overflow: auto;';
   };
@@ -43,6 +39,7 @@ function disableScroll(ref: React.MutableRefObject<HTMLDivElement>) {
 const Wrapper = styled.div`
   width: 100vw;
   height: 100vh;
+  overflow: hidden;
 `;
 
 const Header = styled.div`

--- a/src/components/datepicker/index.tsx
+++ b/src/components/datepicker/index.tsx
@@ -78,6 +78,9 @@ const Container = styled.section`
   background-color: #fff;
   @media screen and (max-width: 480px) {
     position: static;
+
+    height: 90vh;
+    overflow: auto;
   }
 `;
 
@@ -96,8 +99,8 @@ const ButtonContainer = styled.div`
   background-color: #fff;
   @media screen and (max-width: 480px) {
     display: block;
-    width: 100%;
-    position: sticky;
+    width: 50%;
+    position: absolute;
     bottom: 14px;
   }
 `;


### PR DESCRIPTION
# 개요
- 모바일에서 뜨는 팝업의 스크롤을 막음
- 달력이 스크롤 되도록 달력에 높이 줌

# 추가
- 달력 높이를 계산해야 됨.
  - 팝업의 헤더 높이가 vw로 자동 계산되는데 이걸... 고정해야 될 듯?
  - 100vh - 팝업의 헤더 높이
- 달력의 제출 버튼 위치 잡아줘야 됨

일경님 화이팅~